### PR TITLE
Updated to not have to use get_property_int directly.

### DIFF
--- a/addons/source-python/packages/custom/vmchanger/helpers.py
+++ b/addons/source-python/packages/custom/vmchanger/helpers.py
@@ -11,6 +11,5 @@ __all__ = ('get_predicted_view_model', )
 def get_predicted_view_model(player):
 	'Retrieves the current view model predictor representative of the player.'
 	for entity in EntityIter('predicted_viewmodel'):
-		if entity.get_property_int('m_hOwner') != player.inthandle:
-			continue
-		return entity
+		if entity.owner_handle == player.inthandle:
+			return entity


### PR DESCRIPTION
All weapons should have m_Owner as the owner_handle, since [CBaseCombatWeapon](https://github.com/Source-Python-Dev-Team/Source.Python/blob/313ae21031485ebeb19b8722c325b360f2168447/addons/source-python/data/source-python/entities/CBaseCombatWeapon.ini#L12) should be searched prior to [CBaseEntity](https://github.com/Source-Python-Dev-Team/Source.Python/blob/bcec4989c1512cb8b62e262c6fbf16559d3fbb7a/addons/source-python/data/source-python/entities/CBaseEntity.ini#L81) for dynamic attributes.